### PR TITLE
Fix error with adding vimrc to empty dir

### DIFF
--- a/abc_client/service/add.py
+++ b/abc_client/service/add.py
@@ -4,5 +4,11 @@ from abc_client import utils
 
 def add(user_file):
     with utils.YamlEditor(settings.CONFIG_PATH) as yaml:
-        if user_file not in yaml['watch']:
+        try:
+            user_file not in yaml['watch']
+        except TypeError:
+            if yaml is None:
+                yaml = {}
+            yaml.update({'watch': user_file})
+        else:
             yaml['watch'].append(user_file)

--- a/abc_client/utils.py
+++ b/abc_client/utils.py
@@ -18,7 +18,7 @@ def write_to_file(file_name, data):
 
 
 def read_from_file(file_name):
-    with open(file_name, 'r') as f:
+    with open(file_name, 'w+') as f:
         return yaml.load(f)
 
 


### PR DESCRIPTION
close #20 

Using this commit, file 'abc_config.yaml' will create automatically, if it doesn't exist. Also, if this file is empty, there won't be type error anymore